### PR TITLE
add racket-poppler dependency

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection 'multi)
 (define version    "0.1")
-(define deps       '("base" "pict-lib"))
+(define deps       '("base" "pict-lib" "racket-poppler"))
 (define build-deps '( "scribble-lib"
                       "racket-doc"
                       "draw-doc"


### PR DESCRIPTION
Looks like this missing dependency is causing CI to fail, and also prevents latex-pict from installing correctly.